### PR TITLE
[PL-1776] cas overlay build error

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -126,5 +126,9 @@
             <id>shibboleth-releases</id>
             <url>https://build.shibboleth.net/nexus/content/repositories/releases</url>
         </repository>
+        <repository>
+            <id>bintray-uniconiam-maven</id>
+            <url>https://dl.bintray.com/uniconiam/maven</url>
+        </repository>
     </repositories>
 </project>


### PR DESCRIPTION
Seems like jcifs-ext:0.9.4 was removed from all listed repos.